### PR TITLE
feat: add work session enforcement and focus tracking

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -228,6 +228,70 @@ Stop current work session
 harm-cli work stop
 ```
 
+### Work Enforcement (Focus Mode)
+
+Check current violation count
+
+```bash
+harm-cli work violations
+```
+
+Reset violation counter
+
+```bash
+harm-cli work reset-violations
+```
+
+Set enforcement mode
+
+```bash
+harm-cli work set-mode strict      # Strict enforcement
+harm-cli work set-mode moderate    # Track but don't warn (default)
+harm-cli work set-mode coaching    # Gentle reminders
+harm-cli work set-mode off         # No enforcement
+```
+
+### Enforcement Modes Explained
+
+**strict** - Maximum focus enforcement
+
+- Locks you to single project
+- Warns on every project switch
+- Shows distraction count
+- Forces goal review after 3 violations
+
+**moderate** - Balanced tracking (default)
+
+- Tracks violations silently
+- No interruptions
+- View with `harm-cli work violations`
+
+**coaching** - Gentle guidance
+
+- Periodic gentle reminders
+- No strict enforcement
+- Helpful suggestions only
+
+**off** - No enforcement
+
+- Basic work session tracking only
+- No violation tracking
+
+### Configuration
+
+Set enforcement mode permanently
+
+```bash
+export HARM_WORK_ENFORCEMENT=strict
+```
+
+Set distraction threshold
+
+```bash
+export HARM_WORK_DISTRACTION_THRESHOLD=3  # Default
+export HARM_WORK_DISTRACTION_THRESHOLD=5  # More lenient
+```
+
 ---
 
 ## 📊 Activity Tracking

--- a/bin/harm-cli
+++ b/bin/harm-cli
@@ -260,7 +260,16 @@ Commands:
   start <description>  Start a new work session
   stop                 Stop current work session
   status               Show current work session status (default)
+  violations           Show violation count (strict mode)
+  reset-violations     Reset violation counter
+  set-mode <mode>      Set enforcement mode (strict|moderate|coaching|off)
   --help               Show this help
+
+Enforcement Modes:
+  strict     Single project/goal enforcement with warnings
+  moderate   Track violations but don't warn (default)
+  coaching   Gentle reminders only
+  off        No enforcement
 
 Examples:
   harm-cli work start "Phase 3 implementation"
@@ -276,7 +285,10 @@ EOF
         start) work_start "$@" ;;
         stop) work_stop "$@" ;;
         status) work_status "$@" ;;
-        *) die "Unknown work command: $subcmd. Try: start, stop, status" 2 ;;
+        violations) work_get_violations ;;
+        reset-violations) work_reset_violations ;;
+        set-mode) work_set_enforcement "$@" ;;
+        *) die "Unknown work command: $subcmd. Try: start, stop, status, violations, reset-violations, set-mode" 2 ;;
       esac
       ;;
     activity)


### PR DESCRIPTION
Extends work sessions with strict productivity enforcement modes. Detects distractions and helps maintain single-project focus.

Features:
- Four enforcement modes (strict, moderate, coaching, off)
- Project switch detection via chpwd hooks
- Violation counter with configurable threshold
- Automatic warnings on context switches
- Cross-shell state persistence
- Distraction threshold system (default: 3)

Enforcement Modes:
- strict: Single project lock, immediate warnings
- moderate: Silent tracking (default)
- coaching: Gentle reminders only
- off: No enforcement

CLI Commands:
- harm-cli work violations          # Show violation count
- harm-cli work reset-violations    # Reset counter
- harm-cli work set-mode <mode>     # Change enforcement level

How It Works (Strict Mode):
1. Start work session in project A
2. Switch to project B → Violation #1 (warning)
3. Switch to project C → Violation #2 (warning)
4. Switch to project D → Violation #3 (threshold reached) → Shows strong warning with refocus suggestions

State Management:
- Tracks active project and goal
- Persists violations across shell sessions
- Auto-clears on work stop
- JSON state file: ~/.harm-cli/work/enforcement.json

Configuration:
- HARM_WORK_ENFORCEMENT: Set default mode
- HARM_WORK_DISTRACTION_THRESHOLD: Warnings before alert (default: 3)

Implementation:
- Extends existing lib/work.sh (+ 235 LOC)
- Uses chpwd hooks for project detection
- Atomic state persistence
- Comprehensive inline documentation

Integration:
- Hooks into existing work start/stop
- Documentation added to COMMANDS.md
- Help text updated with examples

This enables:
- Single-tasking enforcement
- Focus tracking
- Distraction awareness
- Productivity optimization

Breaking changes: None (enforcement defaults to moderate)
Dependencies: Bash 5+, lib/hooks.sh, lib/util.sh