### PR TITLE
feat(logging): add minimum level filtering and color support to log s…

### DIFF
--- a/bin/harm-cli
+++ b/bin/harm-cli
@@ -352,25 +352,50 @@ Commands:
   --help                  Show this help
 
 Stream Options:
-  --level=LEVEL           Filter by log level (DEBUG|INFO|WARN|ERROR)
-  --format=FORMAT         Output format (plain|json|structured)
+  --level=LEVEL           Filter by minimum log level (shows level and above)
+                          DEBUG: Shows all logs (DEBUG, INFO, WARN, ERROR)
+                          INFO:  Shows INFO, WARN, ERROR
+                          WARN:  Shows WARN, ERROR
+                          ERROR: Shows ERROR only
+  --format=FORMAT         Output format (plain|json|structured|color)
+                          plain: Raw log lines
+                          json: JSON formatted output
+                          structured: Visual indicators (✓ ⚠ ✗ 🔍)
+                          color: Colored plain text
+  --color=WHEN            Colorize output (auto|always|never)
+                          auto: Color if terminal supports it (default)
+                          always: Always colorize
+                          never: Never colorize
 
 Examples:
+  # Stream all logs with auto-color
   harm-cli log stream
+
+  # Stream INFO and above (INFO, WARN, ERROR) with colors
+  harm-cli log stream --level=INFO --color=always
+
+  # Stream errors only
   harm-cli log stream --level=ERROR
-  harm-cli log stream --format=json
-  harm-cli log stream --level=INFO --format=structured
+
+  # Stream in structured format with visual indicators
+  harm-cli log stream --format=structured
+
+  # Stream warnings and errors in JSON format
+  harm-cli log stream --level=WARN --format=json
+
+  # Other log commands
   harm-cli log tail --lines=100
   harm-cli log search "api"
   harm-cli log stats
   harm-cli log clear --force
 
 Features:
-  - Cross-terminal streaming (logs from ALL terminals appear)
-  - Rotation-aware following (continues through log rotation)
-  - Multiple output formats (plain, JSON, structured)
-  - Real-time with zero buffering
-  - Level filtering for focused debugging
+  - ✅ Cross-terminal streaming (logs from ALL terminals appear)
+  - ✅ Rotation-aware following (continues through log rotation)
+  - ✅ Multiple output formats (plain, JSON, structured, color)
+  - ✅ Real-time with zero buffering
+  - ✅ Minimum level filtering (industry standard behavior)
+  - ✅ Auto-colorization based on terminal support
 
 Log Files:
   Main log:  ~/.harm-cli/logs/harm-cli.log

--- a/spec/logging_spec.sh
+++ b/spec/logging_spec.sh
@@ -374,6 +374,50 @@ End
 End
 End
 
+Describe 'Minimum level filtering (_log_build_level_filter)'
+It 'builds correct pattern for DEBUG level (shows all)'
+When call _log_build_level_filter "DEBUG"
+The status should be success
+The output should include "DEBUG"
+The output should include "INFO"
+The output should include "WARN"
+The output should include "ERROR"
+End
+
+It 'builds correct pattern for INFO level (shows INFO+)'
+When call _log_build_level_filter "INFO"
+The status should be success
+The output should include "INFO"
+The output should include "WARN"
+The output should include "ERROR"
+The output should not include "DEBUG"
+End
+
+It 'builds correct pattern for WARN level (shows WARN+)'
+When call _log_build_level_filter "WARN"
+The status should be success
+The output should include "WARN"
+The output should include "ERROR"
+The output should not include "INFO"
+The output should not include "DEBUG"
+End
+
+It 'builds correct pattern for ERROR level (shows ERROR only)'
+When call _log_build_level_filter "ERROR"
+The status should be success
+The output should include "ERROR"
+The output should not include "WARN"
+The output should not include "INFO"
+The output should not include "DEBUG"
+End
+
+It 'handles invalid log level gracefully'
+When call _log_build_level_filter "INVALID"
+The status should be failure
+The output should equal "cat"
+End
+End
+
 Describe 'Format helper functions'
 Describe '_log_format_json_line'
 It 'converts log line to JSON format'
@@ -390,6 +434,36 @@ When call sh -c 'echo "[2025-10-22 12:34:56] [ERROR] [test] Message with quotes 
 The status should be success
 The output should include '"timestamp"'
 The output should include '"level":"ERROR"'
+End
+End
+
+Describe '_log_format_colored_line'
+It 'adds color codes for DEBUG level'
+When call sh -c 'echo "[2025-10-22 12:34:56] [DEBUG] [test] Debug message" | _log_format_colored_line'
+The status should be success
+# Should contain ANSI escape codes for dim text (\033[2m)
+The output should include "DEBUG"
+End
+
+It 'adds color codes for INFO level'
+When call sh -c 'echo "[2025-10-22 12:34:56] [INFO] [test] Info message" | _log_format_colored_line'
+The status should be success
+# Should contain ANSI escape codes for blue (\033[34m)
+The output should include "INFO"
+End
+
+It 'adds color codes for WARN level'
+When call sh -c 'echo "[2025-10-22 12:34:56] [WARN] [test] Warning message" | _log_format_colored_line'
+The status should be success
+# Should contain ANSI escape codes for yellow (\033[33m)
+The output should include "WARN"
+End
+
+It 'adds color codes for ERROR level'
+When call sh -c 'echo "[2025-10-22 12:34:56] [ERROR] [test] Error message" | _log_format_colored_line'
+The status should be success
+# Should contain ANSI escape codes for red (\033[31m)
+The output should include "ERROR"
 End
 End
 


### PR DESCRIPTION
…treaming

Implements industry-standard minimum level filtering where --level=INFO shows INFO, WARN, and ERROR logs (not just exact matches). This matches the behavior of all major logging frameworks (Python logging, syslog, log4j).

Key changes:
- Add --level flag with minimum level semantics (shows level and above)
- Add --color flag with auto/always/never options
- Add _log_build_level_filter() to generate grep patterns dynamically
- Add _log_format_colored_line() for ANSI color formatting
- Update CLI help text with clear examples and explanations
- Add 9 comprehensive tests for new functionality

Why:
The previous exact-match filtering was non-standard and counterintuitive. Users expect --level=WARN to show warnings AND errors, not just warnings. Color support improves readability during debugging sessions.

All tests pass (58/58 logging tests green).