### PR TITLE
feat(proj): Enable seamless project switching via shell function

### DIFF
--- a/bin/harm-cli
+++ b/bin/harm-cli
@@ -634,19 +634,29 @@ Commands:
   --help              Show this help
 
 Examples:
+  # List and manage projects
   harm-cli proj list
   harm-cli proj add ~/harm-cli
   harm-cli proj add ~/myapp myapp
-  harm-cli proj switch myapp
-  eval "$(harm-cli proj switch myapp)"  # Actually switch
+  harm-cli proj remove myapp
+
+  # Switch directories (requires shell function)
+  proj switch myapp          # ✓ Recommended (after init)
+  proj sw myapp              # ✓ Short alias
+  eval "$(harm-cli proj switch myapp)"  # ✓ Manual eval
+
+Setup (Run Once):
+  # Initialize harm-cli to get the proj() helper function
+  eval "$(harm-cli init)"
+
+  # Add to ~/.bashrc or ~/.zshrc to persist across sessions:
+  echo 'eval "$(harm-cli init)"' >> ~/.bashrc
 
 Notes:
   - Projects stored in: ~/.harm-cli/projects/registry.jsonl
   - Project type auto-detected (nodejs, python, rust, go, shell)
-  - Switch outputs cd command (shell limitation)
-
-Shell Function (add to ~/.bashrc):
-  proj() { eval "$(harm-cli proj switch "$@")"; }
+  - The proj() function automatically evaluates switch commands
+  - Use 'harm-cli proj' directly for list/add/remove commands
 EOF
           ;;
         list | ls)

--- a/etc/harm-cli-init.sh
+++ b/etc/harm-cli-init.sh
@@ -37,6 +37,44 @@ if [[ -f "$HARM_CLI_ROOT/lib/hooks.sh" ]]; then
   source "$HARM_CLI_ROOT/lib/hooks.sh"
 fi
 
+# ═══════════════════════════════════════════════════════════════
+# Shell Helper Functions
+# ═══════════════════════════════════════════════════════════════
+
+# proj() - Wrapper for harm-cli proj with automatic directory switching
+#
+# This function wraps the 'harm-cli proj' command and automatically
+# evaluates the 'switch' subcommand, making directory changes work seamlessly.
+#
+# Usage:
+#   proj list          # Same as: harm-cli proj list
+#   proj add ~/myapp   # Same as: harm-cli proj add ~/myapp
+#   proj switch myapp  # Actually switches to the directory!
+#   proj sw myapp      # Short alias for switch
+#
+# Note: For all other proj subcommands, this passes through to harm-cli.
+proj() {
+  # Handle switch/sw subcommand specially
+  if [[ "${1:-}" == "switch" || "${1:-}" == "sw" ]]; then
+    # Execute harm-cli proj switch and capture output
+    local switch_cmd
+    switch_cmd="$(harm-cli proj "$@" 2>&1)"
+    local exit_code=$?
+
+    # If successful and output starts with "cd ", evaluate it
+    if [[ $exit_code -eq 0 ]] && [[ "$switch_cmd" =~ ^cd\  ]]; then
+      eval "$switch_cmd"
+    else
+      # Print error message if failed
+      echo "$switch_cmd"
+      return $exit_code
+    fi
+  else
+    # Pass through all other commands
+    harm-cli proj "$@"
+  fi
+}
+
 # Optional: Remind about work session if not active
 # Uncomment to enable:
 # if command -v harm-cli >/dev/null 2>&1; then
@@ -46,4 +84,4 @@ fi
 #   fi
 # fi
 
-echo "✓ harm-cli initialized"
+echo "✓ harm-cli initialized (with proj() helper function)"

--- a/lib/proj.sh
+++ b/lib/proj.sh
@@ -410,8 +410,20 @@ proj_switch() {
     return "$EXIT_INVALID_ARGS"
   fi
 
-  # Output cd command
+  # Output cd command with helpful hint
   echo "cd \"$path\""
+
+  # If in TTY, show helpful message about shell function
+  if [[ -t 1 ]] && [[ "${HARM_CLI_FORMAT:-text}" == "text" ]]; then
+    echo "" >&2
+    echo "💡 To automatically switch directories, use the shell function:" >&2
+    echo "   eval \"\$(harm-cli proj switch $name)\"" >&2
+    echo "" >&2
+    echo "Or initialize once to get the 'proj' helper function:" >&2
+    echo "   eval \"\$(harm-cli init)\"" >&2
+    echo "   proj switch $name  # Will switch automatically!" >&2
+  fi
+
   log_info "proj" "Project switch prepared" "Path: $path"
 
   return 0


### PR DESCRIPTION
## Summary

Implements user goal from **Oct 22 #3**: *"make project switch actually switch to the project"*

This PR adds a `proj()` shell helper function that makes project directory switching seamless. Users no longer need to manually wrap `harm-cli proj switch` with `eval`.

## Changes

### 1. Shell Function (`etc/harm-cli-init.sh`)
- Added `proj()` wrapper function that:
  - Automatically evaluates `switch` and `sw` subcommands
  - Passes through all other commands (list, add, remove) to harm-cli
  - Provides error messages if switch fails

### 2. Enhanced Help Text (`bin/harm-cli`)
- Clearer examples showing recommended usage
- Setup instructions with one-time initialization
- Documents both the shell function and manual eval approaches

### 3. Helpful Hints (`lib/proj.sh`)
- When users run `harm-cli proj switch` directly, show helpful guidance
- Suggests using the shell function or manual eval
- Only shows hints in interactive terminals (not in scripts)

## Usage

**Before this PR:**
```bash
eval "$(harm-cli proj switch myapp)"  # Required every time
```

**After this PR (one-time setup):**
```bash
# Initialize once
eval "$(harm-cli init)"

# Then use seamlessly
proj switch myapp       # ✓ Automatically switches!
proj sw myapp          # ✓ Short alias works too
proj list              # ✓ Other commands pass through
```

**Persistence (optional):**
```bash
echo 'eval "$(harm-cli init)"' >> ~/.bashrc  # Load on every shell
```

## Test Plan

- ✅ Manual testing: Shell function works correctly for switch/sw
- ✅ Manual testing: Other proj commands (list/add/remove) pass through
- ✅ Manual testing: Error messages display when project not found
- ✅ Manual testing: Helpful hints show when using direct command
- ✅ Backward compatible: Direct `harm-cli proj switch` still works
- ✅ All pre-commit hooks passed (shellcheck, shfmt, codespell)

**Note:** 23 test failures exist on main branch (pre-existing, not introduced by this PR)

## Benefits

- **Improved UX**: More intuitive, feels like a native shell command
- **Backward Compatible**: Existing workflows continue to work
- **Self-Documenting**: Helpful hints guide users to better approach
- **Minimal Code**: Only ~50 lines added across 3 files

## Related

- Closes goal from Oct 22 #3: "make project switch actually switch to the project"
- Part of Phase 1.2 implementation plan